### PR TITLE
reprogramación de segundo curso de lightning - fecha propuesta

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@ layout: default
          <div class="text-center">
             <h4 class="section-heading text-uppercase text-center">Curso de Lightning Network</h4>
             <p style="text-align: justify;"><h7>El curso tendrá un enfoque sobre la programación de Lightning Network, se utilizará como guía el libro Mastering Lightning, se formarán grupos de estudio, se generarán discusiones, se tendrán prácticas, se contará con asesores capacitados, los cuales tienen el conocimiento para orientar a los estudiantes y resolver sus inquietudes.</h7></p>
-            <p style="text-align: justify;"><h7>El curso dará inicio el martes 26 de julio de 2022, las clases serán los días martes y jueves de 8 a 10 PM. La duración será de 6 semanas. </h7></p>
+            <p style="text-align: justify;"><h7>El curso dará inicio el martes 11 de octubre de 2022, las clases serán los días martes y jueves de 8 a 10 PM. La duración será de 6 semanas. </h7></p>
             <p style="text-align: justify;"><h7>Puedes descargar aquí el <b><a style=" text-decoration: none;" target="_blank" href="resources/Temario_Curso_Lightning.pdf">temario del curso de Lightning</a></b></h7></p>
 		 </div>
       </div>


### PR DESCRIPTION
Se reprograma fecha del segundo  curso de Lightning, y se propone que sea para el martes 18 de octubre de este año